### PR TITLE
WIP: Switch to UNWIND queries

### DIFF
--- a/rlay-backend-neo4j/src/lib.rs
+++ b/rlay-backend-neo4j/src/lib.rs
@@ -347,13 +347,14 @@ impl Neo4jBackend {
                     }
                 }
             }
-            val["relationships"] = serde_json::Value::Array(
+
+            val.insert("relationships".to_string(), serde_json::Value::Array(
                 relationships
                     .iter()
                     .map(serde_json::to_value)
                     .map(|r| r.unwrap())
-                    .collect::<Vec<_>>()
-            );
+                    .collect()
+            ));
             _entities.push(val);
         }
 
@@ -406,6 +407,14 @@ impl BackendRpcMethods for Neo4jBackend {
         _options_object: &Value,
     ) -> BoxFuture<Result<Cid, Error>> {
         Box::pin(self.store_entity(entity.to_owned()))
+    }
+
+    fn store_entities(
+        &mut self,
+        entities: &Vec<Entity>,
+        _options_object: &Value,
+    ) -> BoxFuture<Result<Vec<Cid>, Error>> {
+        Box::pin(self.store_entities(entities.to_owned()))
     }
 
     fn get_entity(&mut self, cid: &str) -> BoxFuture<Result<Option<Entity>, Error>> {

--- a/rlay-backend/src/lib.rs
+++ b/rlay-backend/src/lib.rs
@@ -27,6 +27,18 @@ pub trait BackendRpcMethods {
     }
 
     #[allow(unused_variables)]
+    fn store_entities(
+        &mut self,
+        entities: &Vec<Entity>,
+        options_object: &Value,
+    ) -> BoxFuture<Result<Vec<Cid>, Error>> {
+        err(err_msg(
+            "The requested backend does not support this RPC method.",
+        ))
+        .boxed()
+    }
+
+    #[allow(unused_variables)]
     fn get_entity(&mut self, cid: &str) -> BoxFuture<Result<Option<Entity>, Error>> {
         err(err_msg(
             "The requested backend does not support this RPC method.",

--- a/rlay-client/src/backend/mod.rs
+++ b/rlay-client/src/backend/mod.rs
@@ -178,6 +178,26 @@ impl BackendRpcMethods for Backend {
         }
     }
 
+    fn store_entities(
+        &mut self,
+        entities: &Vec<Entity>,
+        options_object: &Value,
+    ) -> BoxFuture<Result<Vec<Cid>, Error>> {
+        match self {
+            #[cfg(feature = "backend_neo4j")]
+            Backend::Neo4j(backend) => {
+                BackendRpcMethods::store_entities(backend, entities, options_object)
+            }
+            #[cfg(feature = "backend_redisgraph")]
+            Backend::Redisgraph(backend) => {
+                BackendRpcMethods::store_entities(backend, entities, options_object)
+            }
+            Backend::Ethereum(backend) => {
+                BackendRpcMethods::store_entities(backend, entities, options_object)
+            }
+        }
+    }
+
     fn get_entity(&mut self, cid: &str) -> BoxFuture<Result<Option<Entity>, Error>> {
         match self {
             #[cfg(feature = "backend_neo4j")]

--- a/rlay-client/src/rpc/mod.rs
+++ b/rlay-client/src/rpc/mod.rs
@@ -163,6 +163,9 @@ async fn handle_jsonrpc(
         "rlay_experimentalStoreEntity" => Some(
             rpc_rlay_experimental_store_entity(full_config, sync_state, params.to_owned()).await?,
         ),
+        "rlay_experimentalStoreEntities" => Some(
+            rpc_rlay_experimental_store_entities(full_config, sync_state, params.to_owned()).await?,
+        ),
         "rlay_experimentalGetEntity" => Some(
             rpc_rlay_experimental_get_entity(full_config, sync_state, params.to_owned()).await?,
         ),
@@ -272,6 +275,48 @@ async fn rpc_rlay_experimental_store_entity(
         .unwrap();
 
     Ok(cid)
+}
+
+async fn rpc_rlay_experimental_store_entities(
+    config: Config,
+    sync_state: MultiBackendSyncState,
+    params_array: Vec<Value>,
+) -> JsonRpcResult<Value> {
+    let entity_objects = params_array
+        .get(0)
+        .ok_or(jsonrpc_core::Error::invalid_params(
+            "Mandatory parameter 'entities' missing",
+        ))
+        .unwrap()
+        .as_array().unwrap();
+
+    let entities: Vec<Entity> = entity_objects
+        .iter()
+        .map(|entity_object| {
+            let web3_entities: FormatWeb3<Entity> = serde_json::from_value(entity_object.clone())
+                .map_err(|err| jsonrpc_core::Error::invalid_params(err.description()))
+                .unwrap();
+            return web3_entities.0
+        })
+        .collect();
+
+    let options_object = extract_options_object(&params_array, 1);
+    let backend_name = extract_option_backend(options_object.clone());
+
+    let mut backend = backend_from_backend_name(&config, &sync_state, backend_name).await?;
+
+    let cids = BackendRpcMethods::store_entities(&mut backend, &entities, &options_object.unwrap())
+        .map_err(failure_into_jsonrpc_err)
+        .map_ok(|raw_cids| {
+            return raw_cids.iter().map(|raw_cid| {
+                let cid: String = format!("0x{}", raw_cid.to_bytes().to_hex());
+                serde_json::to_value(cid).unwrap()
+            })
+            .collect();
+        })
+        .await?;
+
+    Ok(cids)
 }
 
 async fn rpc_rlay_experimental_get_entity(


### PR DESCRIPTION
We will merge that into the neo4j_query_params branch first and then from there into master.

Created that initially because I wasn't sure if UNWIND also performs for storing a single entity.

Turns out it does, so we can move that over there soon.