### PR TITLE
WIP: Add resolve_entity(ies) rpc endpoints for Neo4J

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,6 +1351,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nonparallel 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlay-backend 0.1.0",
  "rlay_ontology 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1358,6 +1359,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testcontainers 0.8.1 (git+https://github.com/testcontainers/testcontainers-rs?rev=b6f9dbe82478f28f5c5b46686bcc4dfe422fd9ea)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/rlay-backend-neo4j/Cargo.toml
+++ b/rlay-backend-neo4j/Cargo.toml
@@ -22,6 +22,8 @@ serde_derive = "1.0.79"
 serde_json = { version = "1.0.22", features = ["preserve_order"] }
 tokio = "0.2.0"
 err-ctx = "0.2.3"
+static_assertions = "1.1.0"
+once_cell = "1.3.1"
 
 [dev-dependencies]
 testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", rev = "b6f9dbe82478f28f5c5b46686bcc4dfe422fd9ea" }

--- a/rlay-backend-neo4j/src/lib.rs
+++ b/rlay-backend-neo4j/src/lib.rs
@@ -224,15 +224,14 @@ impl Neo4jBackend {
     }
 
     fn pattern_rows_to_entities(rows: Rows) -> Vec<Entity> {
-        rows
-            .map(|row| {
-                let data: Value = row.get("data").unwrap();
-                Self::pattern_object_to_entities(&data)
-            })
-            .fold(vec![], |mut all_entities, entities| {
-                all_entities.extend(entities);
-                all_entities
-            })
+        rows.map(|row| {
+            let data: Value = row.get("data").unwrap();
+            Self::pattern_object_to_entities(&data)
+        })
+        .fold(vec![], |mut all_entities, entities| {
+            all_entities.extend(entities);
+            all_entities
+        })
     }
 
     async fn get_entity(&mut self, cid: String) -> Result<Option<Entity>, Error> {
@@ -606,14 +605,16 @@ impl BackendRpcMethodNeo4jQuery for Neo4jBackend {
     }
 }
 
-impl BackendRpcMethods for Neo4jBackend {
+impl BackendRpcMethodResolveEntity for Neo4jBackend {
     fn resolve_entity(
         &mut self,
         cid: &str,
     ) -> BoxFuture<Result<HashMap<String, Vec<Entity>>, Error>> {
         Box::pin(self.resolve_entity(cid.to_owned()))
     }
+}
 
+impl BackendRpcMethodResolveEntities for Neo4jBackend {
     fn resolve_entities(
         &mut self,
         cids: Vec<String>,
@@ -621,3 +622,5 @@ impl BackendRpcMethods for Neo4jBackend {
         Box::pin(self.resolve_entities(cids))
     }
 }
+
+impl BackendRpcMethods for Neo4jBackend {}

--- a/rlay-backend-neo4j/src/lib.rs
+++ b/rlay-backend-neo4j/src/lib.rs
@@ -367,16 +367,16 @@ impl Neo4jBackend {
             {{
                 self: n0,
                 self_labels: labels(n0),
-                children: [(n0)-[r0]->(n1) | {{
+                children: [(n0:RlayEntity)-[r0]->(n1:RlayEntity) | {{
                     rel_type: type(r0),
                     self: n1,
                     self_labels: labels(n1),
-                    children: [(n1)-[r1]->(n2) | {{
+                    children: [(n1:RlayEntity)-[r1]->(n2:RlayEntity) | {{
                         rel_type: type(r1),
                         self: n2,
                         self_labels: labels(n2),
                         children: CASE single(x IN labels(n2) WHERE x = 'Individual' AND n2 <> n0) WHEN TRUE
-                            THEN [(n2)-[r2]->(n3) | {{
+                            THEN [(n2:RlayEntity)-[r2]->(n3:RlayEntity) | {{
                                 rel_type: type(r2),
                                 self: n3,
                                 self_labels: labels(n3)
@@ -384,16 +384,16 @@ impl Neo4jBackend {
                             END
                     }}]
                 }}] +
-                [(n0)<-[r0:subject]-(n1) | {{
+                [(n0:RlayEntity)<-[r0:subject]-(n1:RlayEntity) | {{
                     rel_type: type(r0),
                     self: n1,
                     self_labels: labels(n1),
-                    children: [(n1)-[r1]->(n2) | {{
+                    children: [(n1:RlayEntity)-[r1]->(n2:RlayEntity) | {{
                         rel_type: type(r1),
                         self: n2,
                         self_labels: labels(n2),
                         children: CASE single(x IN labels(n2) WHERE x = 'Individual' AND n2 <> n0) WHEN TRUE
-                            THEN [(n2)-[r2]->(n3) | {{
+                            THEN [(n2:RlayEntity)-[r2]->(n3:RlayEntity) | {{
                                 rel_type: type(r2),
                                 self: n3,
                                 self_labels: labels(n3)

--- a/rlay-backend-redisgraph/src/lib.rs
+++ b/rlay-backend-redisgraph/src/lib.rs
@@ -49,7 +49,7 @@ impl RedisgraphBackend {
         trace!("Creating new connection pool for backend.");
         let new_connection = self.config.connection_pool().await;
         let _ = self.client.set(new_connection.clone());
-        return Ok(new_connection);
+        Ok(new_connection)
     }
 
     async fn get_entity(&self, cid: String) -> Result<Option<Entity>, Error> {
@@ -305,7 +305,7 @@ pub struct SyncState {
 
 impl BackendRpcMethodGetEntity for RedisgraphBackend {
     fn get_entity(&mut self, cid: &str) -> BoxFuture<Result<Option<Entity>, Error>> {
-        Box::pin(RedisgraphBackend::get_entity(self, cid.to_owned()))
+        Box::pin(Self::get_entity(self, cid.to_owned()))
     }
 }
 

--- a/rlay-backend-redisgraph/src/lib.rs
+++ b/rlay-backend-redisgraph/src/lib.rs
@@ -328,4 +328,6 @@ impl BackendRpcMethodNeo4jQuery for RedisgraphBackend {
 impl BackendRpcMethodGetEntities for RedisgraphBackend {}
 impl BackendRpcMethodListCids for RedisgraphBackend {}
 impl BackendRpcMethodStoreEntities for RedisgraphBackend {}
+impl BackendRpcMethodResolveEntity for RedisgraphBackend {}
+impl BackendRpcMethodResolveEntities for RedisgraphBackend {}
 impl BackendRpcMethods for RedisgraphBackend {}

--- a/rlay-backend/src/rpc.rs
+++ b/rlay-backend/src/rpc.rs
@@ -4,6 +4,7 @@ use failure::{err_msg, Error};
 use futures::future::{err, BoxFuture, FutureExt};
 use rlay_ontology::ontology::Entity;
 use serde_json::Value;
+use std::collections::HashMap;
 
 #[delegatable_trait]
 pub trait BackendRpcMethodGetEntity {
@@ -89,7 +90,10 @@ pub trait BackendRpcMethods:
     + BackendRpcMethodNeo4jQuery
 {
     #[allow(unused_variables)]
-    fn resolve_entity(&mut self, cid: &str) -> BoxFuture<Result<Option<Entity>, Error>> {
+    fn resolve_entity(
+        &mut self,
+        cid: &str,
+    ) -> BoxFuture<Result<HashMap<String, Vec<Entity>>, Error>> {
         err(err_msg(
             "The requested backend does not support this RPC method.",
         ))
@@ -97,7 +101,10 @@ pub trait BackendRpcMethods:
     }
 
     #[allow(unused_variables)]
-    fn resolve_entities(&mut self, cids: Vec<String>) -> BoxFuture<Result<Vec<Entity>, Error>> {
+    fn resolve_entities(
+        &mut self,
+        cids: Vec<String>,
+    ) -> BoxFuture<Result<HashMap<String, Vec<Entity>>, Error>> {
         err(err_msg(
             "The requested backend does not support this RPC method.",
         ))

--- a/rlay-backend/src/rpc.rs
+++ b/rlay-backend/src/rpc.rs
@@ -88,4 +88,19 @@ pub trait BackendRpcMethods:
     + BackendRpcMethodListCids
     + BackendRpcMethodNeo4jQuery
 {
+    #[allow(unused_variables)]
+    fn resolve_entity(&mut self, cid: &str) -> BoxFuture<Result<Option<Entity>, Error>> {
+        err(err_msg(
+            "The requested backend does not support this RPC method.",
+        ))
+        .boxed()
+    }
+
+    #[allow(unused_variables)]
+    fn resolve_entities(&mut self, cids: Vec<String>) -> BoxFuture<Result<Vec<Entity>, Error>> {
+        err(err_msg(
+            "The requested backend does not support this RPC method.",
+        ))
+        .boxed()
+    }
 }

--- a/rlay-backend/src/rpc.rs
+++ b/rlay-backend/src/rpc.rs
@@ -80,15 +80,8 @@ pub trait BackendRpcMethodNeo4jQuery {
     }
 }
 
-pub trait BackendRpcMethods:
-    Send
-    + BackendRpcMethodGetEntity
-    + BackendRpcMethodGetEntities
-    + BackendRpcMethodStoreEntity
-    + BackendRpcMethodStoreEntities
-    + BackendRpcMethodListCids
-    + BackendRpcMethodNeo4jQuery
-{
+#[delegatable_trait]
+pub trait BackendRpcMethodResolveEntity {
     #[allow(unused_variables)]
     fn resolve_entity(
         &mut self,
@@ -99,7 +92,10 @@ pub trait BackendRpcMethods:
         ))
         .boxed()
     }
+}
 
+#[delegatable_trait]
+pub trait BackendRpcMethodResolveEntities {
     #[allow(unused_variables)]
     fn resolve_entities(
         &mut self,
@@ -110,4 +106,17 @@ pub trait BackendRpcMethods:
         ))
         .boxed()
     }
+}
+
+pub trait BackendRpcMethods:
+    Send
+    + BackendRpcMethodGetEntity
+    + BackendRpcMethodGetEntities
+    + BackendRpcMethodStoreEntity
+    + BackendRpcMethodStoreEntities
+    + BackendRpcMethodResolveEntity
+    + BackendRpcMethodResolveEntities
+    + BackendRpcMethodListCids
+    + BackendRpcMethodNeo4jQuery
+{
 }

--- a/rlay-client/src/backend/mod.rs
+++ b/rlay-client/src/backend/mod.rs
@@ -76,8 +76,10 @@ sa::assert_impl_all!(Backend: Send);
 #[delegate(rlay_backend::BackendRpcMethodGetEntity)]
 // TODO: Bugged; See https://github.com/hobofan/ambassador/issues/16
 // #[delegate(rlay_backend::BackendRpcMethodGetEntities)]
+// #[delegate(rlay_backend::BackendRpcMethodResolveEntities)]
 #[delegate(rlay_backend::BackendRpcMethodStoreEntity)]
 #[delegate(rlay_backend::BackendRpcMethodStoreEntities)]
+#[delegate(rlay_backend::BackendRpcMethodResolveEntity)]
 #[delegate(rlay_backend::BackendRpcMethodListCids)]
 #[delegate(rlay_backend::BackendRpcMethodNeo4jQuery)]
 pub enum Backend {
@@ -127,19 +129,7 @@ impl BackendRpcMethodGetEntities for Backend {
     }
 }
 
-impl BackendRpcMethods for Backend {
-    fn resolve_entity(
-        &mut self,
-        cid: &str,
-    ) -> BoxFuture<Result<HashMap<String, Vec<Entity>>, Error>> {
-        match self {
-            #[cfg(feature = "backend_neo4j")]
-            Backend::Neo4j(backend) => BackendRpcMethods::resolve_entity(backend, cid),
-            #[cfg(feature = "backend_redisgraph")]
-            Backend::Redisgraph(backend) => BackendRpcMethods::resolve_entity(backend, cid),
-        }
-    }
-
+impl BackendRpcMethodResolveEntities for Backend {
     fn resolve_entities(
         &mut self,
         cids: Vec<String>,
@@ -152,3 +142,5 @@ impl BackendRpcMethods for Backend {
         }
     }
 }
+
+impl BackendRpcMethods for Backend {}

--- a/rlay-client/src/backend/mod.rs
+++ b/rlay-client/src/backend/mod.rs
@@ -9,7 +9,6 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 
 use crate::config::backend::BackendConfig;
 
@@ -43,7 +42,7 @@ impl SyncState {
     #[cfg(feature = "backend_neo4j")]
     pub async fn new_neo4j(config: &Neo4jBackendConfig) -> Self {
         SyncState::Neo4j(Neo4jSyncState {
-            connection_pool: Some(Arc::new(async { config.connection_pool().await }.await)),
+            connection_pool: Some(async { config.connection_pool().await }.await),
         })
     }
 

--- a/rlay-client/src/backend/mod.rs
+++ b/rlay-client/src/backend/mod.rs
@@ -6,6 +6,7 @@ use rlay_backend::rpc::*;
 use rlay_backend::BackendFromConfigAndSyncState;
 use rlay_ontology::ontology::Entity;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -126,4 +127,28 @@ impl BackendRpcMethodGetEntities for Backend {
     }
 }
 
-impl BackendRpcMethods for Backend {}
+impl BackendRpcMethods for Backend {
+    fn resolve_entity(
+        &mut self,
+        cid: &str,
+    ) -> BoxFuture<Result<HashMap<String, Vec<Entity>>, Error>> {
+        match self {
+            #[cfg(feature = "backend_neo4j")]
+            Backend::Neo4j(backend) => BackendRpcMethods::resolve_entity(backend, cid),
+            #[cfg(feature = "backend_redisgraph")]
+            Backend::Redisgraph(backend) => BackendRpcMethods::resolve_entity(backend, cid),
+        }
+    }
+
+    fn resolve_entities(
+        &mut self,
+        cids: Vec<String>,
+    ) -> BoxFuture<Result<HashMap<String, Vec<Entity>>, Error>> {
+        match self {
+            #[cfg(feature = "backend_neo4j")]
+            Backend::Neo4j(backend) => BackendRpcMethods::resolve_entities(backend, cids),
+            #[cfg(feature = "backend_redisgraph")]
+            Backend::Redisgraph(backend) => BackendRpcMethods::resolve_entities(backend, cids),
+        }
+    }
+}


### PR DESCRIPTION
## Note

This is a WIP and not ready for merging yet - it does work though and can be tested.

CLOSES: #55 

## Overview

This PR adds a native `resolve` functionality for entities/cids which was previously left for client implementation through the `experimentalNeo4JQuery` endpoint. This was also the single biggest blocker for using other storage backends like RedisGraph as the client does not automatically know what storage backend is used at the rlay server.

The native `resolve` is on average about 2x faster and more resourceful with rlay/neo4j connections. E.g. it is possible now to resolve hundreds of entities with a single connection. 

## Performance Benchmark Logs

Following the logs for resolving 50 large individuals (with hundreds of property and assertive assertions) and their resolve time in ms. (`resolve` => native resolve, `resolveFallback` old via experimentalNeo4JQuery). Note that `resolve` only uses a single connection, while resolveFallback uses the specified maximum of 10.
``` 
rlayPerformance:read:readLimit:10:entities:50:resolve 819ms +0ms
rlayPerformance:read:readLimit:10:entities:50:resolveFallback 964ms +0ms
```

And here for 10, 5, and 1 large individuals respectively.

```
  rlayPerformance:read:readLimit:10:entities:1:resolve 5ms +0ms
  rlayPerformance:read:readLimit:10:entities:1:resolveFallback 14ms +0ms
  rlayPerformance:read:readLimit:10:entities:5:resolve 15ms +0ms
  rlayPerformance:read:readLimit:10:entities:5:resolveFallback 39ms +0ms
  rlayPerformance:read:readLimit:10:entities:10:resolve 45ms +0ms
  rlayPerformance:read:readLimit:10:entities:10:resolveFallback 95ms +0ms
```

## Todo

- [x] Gather performance benchmarks
- [x] Refactor code (but review with @hobofan first)
- [x] Merge #53  into master before merging this PR

## Future Todos

Left for a future exercise are:

1) [ ] `resolve` does a property and assertion resolve atm. The overhead on this seems to be negligible for entities with no assertions. However, given the query it would be trivial to split those into two additional resolve endpoints like `resolveProperties` and `resolveAssertions` in the unlikely (?) case that one only wants to resolve properties or assertions.
2) [ ] a function for generating the [Pattern Comprehension Query](https://medium.com/neo4j/loading-graph-data-for-an-object-graph-mapper-or-graphql-5103b1a8b66e) for various depths
3) [ ] given (2); adding an additional argument to `resolve` to resolve entities up to a specified depth
4) [ ] given (3); `get_entities` calls `resolve(depth = 0)`