### PR TITLE
feat(filter): Batch filters for resolve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
  "cid_fork_rlay 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlay-plugin-interface 0.1.0",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1464,6 +1465,7 @@ dependencies = [
  "ambassador 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlay-backend 0.1.0",
  "rlay_ontology 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -125,7 +125,7 @@ name = "bb8_cypher"
 version = "0.4.0"
 source = "git+https://github.com/hobofan/bb8-cypher?rev=548efa44b0aacf617ba386182d674274d5ca4a09#548efa44b0aacf617ba386182d674274d5ca4a09"
 dependencies = [
- "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "l337 0.0.0 (git+https://github.com/OneSignal/L3-37?rev=a970fe669787c4caf8ae699870b97ed1d7616f00)",
  "rusted_cypher 1.1.0 (git+https://github.com/hobofan/rusted-cypher?rev=61829fe43395c7c78be835b0045222a906f184f4)",
@@ -436,6 +436,7 @@ dependencies = [
 name = "example-filter-plugin"
 version = "0.1.0"
 dependencies = [
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "cid_fork_rlay 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlay-plugin-interface 0.1.0",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -858,7 +859,7 @@ name = "l337"
 version = "0.0.0"
 source = "git+https://github.com/OneSignal/L3-37?rev=a970fe669787c4caf8ae699870b97ed1d7616f00#a970fe669787c4caf8ae699870b97ed1d7616f00"
 dependencies = [
- "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1349,6 +1350,7 @@ name = "rlay-backend"
 version = "0.1.0"
 dependencies = [
  "ambassador 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "cid_fork_rlay 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1360,6 +1362,7 @@ dependencies = [
 name = "rlay-backend-neo4j"
 version = "0.1.0"
 dependencies = [
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "bb8_cypher 0.4.0 (git+https://github.com/hobofan/bb8-cypher?rev=548efa44b0aacf617ba386182d674274d5ca4a09)",
  "cid_fork_rlay 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1387,6 +1390,7 @@ dependencies = [
 name = "rlay-backend-redisgraph"
 version = "0.1.0"
 dependencies = [
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "cid_fork_rlay 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1412,6 +1416,7 @@ version = "0.2.7"
 dependencies = [
  "ambassador 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "cid_fork_rlay 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dialoguer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1447,6 +1452,7 @@ dependencies = [
 name = "rlay-jsonrpc-client"
 version = "0.1.0"
 dependencies = [
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1463,6 +1469,7 @@ name = "rlay-plugin-interface"
 version = "0.1.0"
 dependencies = [
  "ambassador 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlay-backend 0.1.0",
  "rlay_ontology 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2069,7 +2076,7 @@ dependencies = [
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum ascii 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 "checksum assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2dc477793bd82ec39799b6f6b3df64938532fdf2ab0d49ef817eac65856a5a1e"
-"checksum async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c8df72488e87761e772f14ae0c2480396810e51b2c2ade912f97f0f7e5b95e3c"
+"checksum async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"

--- a/example-filter-plugin/Cargo.toml
+++ b/example-filter-plugin/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib"]
 cid = { package = "cid_fork_rlay", version = "0.3.1" }
 rlay-plugin-interface = { path = "../rlay-plugin-interface" }
 rustc-hex = "1.0.0"
+serde_json = "1"

--- a/example-filter-plugin/Cargo.toml
+++ b/example-filter-plugin/Cargo.toml
@@ -12,3 +12,4 @@ cid = { package = "cid_fork_rlay", version = "0.3.1" }
 rlay-plugin-interface = { path = "../rlay-plugin-interface" }
 rustc-hex = "1.0.0"
 serde_json = "1"
+async-trait = "0.1.24"

--- a/rlay-backend-neo4j/Cargo.toml
+++ b/rlay-backend-neo4j/Cargo.toml
@@ -24,6 +24,7 @@ tokio = "0.2.0"
 err-ctx = "0.2.3"
 static_assertions = "1.1.0"
 once_cell = "1.3.1"
+async-trait = "0.1.24"
 
 [dev-dependencies]
 testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", rev = "b6f9dbe82478f28f5c5b46686bcc4dfe422fd9ea" }

--- a/rlay-backend-neo4j/tests/lib.rs
+++ b/rlay-backend-neo4j/tests/lib.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use nonparallel::nonparallel;
 use rlay_backend::rpc::*;
-use rlay_backend::BackendRpcMethods;
+use rlay_backend::GetEntity;
 use rlay_backend_neo4j::*;
 use rlay_ontology::prelude::*;
 use rustc_hex::{FromHex, ToHex};
@@ -76,7 +76,20 @@ fn store_and_get_roundtrip_works() {
     let formatted_cid: String = format!("0x{}", inserted_cid.to_bytes().to_hex());
 
     let retrieved_entity = rt
-        .block_on(backend.get_entity(&formatted_cid))
+        .block_on(BackendRpcMethodGetEntity::get_entity(
+            &mut backend,
+            &formatted_cid,
+        ))
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        inserted_entity, retrieved_entity,
+        "inserted and retrieved entity don't match"
+    );
+
+    let retrieved_entity = rt
+        .block_on(GetEntity::get_entity(&backend, &inserted_cid.to_bytes()))
         .unwrap()
         .unwrap();
 
@@ -165,7 +178,8 @@ fn get_entity_leaf_node_returns_none() {
         .unwrap();
 
     let retrieved_entity = rt
-        .block_on(backend.get_entity(
+        .block_on(BackendRpcMethodGetEntity::get_entity(
+            &mut backend,
             "019580031b201111111111111111111111111111111111111111111111111111111111111111",
         ))
         .unwrap();

--- a/rlay-backend-redisgraph/Cargo.toml
+++ b/rlay-backend-redisgraph/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = { version = "1.0.22", features = ["preserve_order"] }
 itertools = "0.8.0"
 static_assertions = "1.1.0"
 once_cell = "1.3.1"
+async-trait = "0.1.24"
 
 [dev-dependencies]
 testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", rev = "b6f9dbe82478f28f5c5b46686bcc4dfe422fd9ea" }

--- a/rlay-backend-redisgraph/src/lib.rs
+++ b/rlay-backend-redisgraph/src/lib.rs
@@ -18,10 +18,11 @@ use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use redis::{aio::MultiplexedConnection, FromRedisValue};
 use rlay_backend::rpc::*;
-use rlay_backend::{BackendFromConfigAndSyncState, GetEntity};
+use rlay_backend::{BackendFromConfigAndSyncState, GetEntity, ResolveEntity};
 use rlay_ontology::prelude::*;
 use rustc_hex::ToHex;
 use serde_json::Value;
+use std::collections::HashMap;
 
 use crate::config::RedisgraphBackendConfig;
 use crate::parse::{CidList, GetQueryRelationship};
@@ -306,9 +307,17 @@ pub struct SyncState {
 impl<'a> GetEntity<'a> for RedisgraphBackend {
     type F = BoxFuture<'a, Result<Option<Entity>, Error>>;
 
-    fn get_entity(&'a self, cid: &[u8]) -> Self::F {
+    fn get_entity(&'a self, _cid: &[u8]) -> Self::F {
         todo!()
         // future::ready(Ok(self.get(cid).map(|n| n.to_owned()))).boxed()
+    }
+}
+
+impl<'a> ResolveEntity<'a> for RedisgraphBackend {
+    type F = BoxFuture<'a, Result<HashMap<Vec<u8>, Vec<Entity>>, Error>>;
+
+    fn resolve_entity(&'a self, _cid: &[u8]) -> Self::F {
+        todo!()
     }
 }
 

--- a/rlay-backend-redisgraph/src/lib.rs
+++ b/rlay-backend-redisgraph/src/lib.rs
@@ -10,6 +10,7 @@ extern crate static_assertions as sa;
 pub mod config;
 mod parse;
 
+use async_trait::async_trait;
 use cid::{Cid, ToCid};
 use failure::{format_err, Error};
 use futures::future::BoxFuture;
@@ -304,19 +305,17 @@ pub struct SyncState {
     pub connection_pool: Option<MultiplexedConnection>,
 }
 
-impl<'a> GetEntity<'a> for RedisgraphBackend {
-    type F = BoxFuture<'a, Result<Option<Entity>, Error>>;
-
-    fn get_entity(&'a self, _cid: &[u8]) -> Self::F {
+#[async_trait]
+impl GetEntity for RedisgraphBackend {
+    async fn get_entity(&self, _cid: &[u8]) -> Result<Option<Entity>, Error> {
         todo!()
         // future::ready(Ok(self.get(cid).map(|n| n.to_owned()))).boxed()
     }
 }
 
-impl<'a> ResolveEntity<'a> for RedisgraphBackend {
-    type F = BoxFuture<'a, Result<HashMap<Vec<u8>, Vec<Entity>>, Error>>;
-
-    fn resolve_entity(&'a self, _cid: &[u8]) -> Self::F {
+#[async_trait]
+impl ResolveEntity for RedisgraphBackend {
+    async fn resolve_entity(&self, _cid: &[u8]) -> Result<HashMap<Vec<u8>, Vec<Entity>>, Error> {
         todo!()
     }
 }

--- a/rlay-backend/Cargo.toml
+++ b/rlay-backend/Cargo.toml
@@ -12,6 +12,7 @@ failure = "0.1.1"
 serde_json = { version = "1.0.22", features = ["preserve_order"] }
 futures = "0.3.0"
 ambassador = "0.2.1"
+async-trait = "0.1.24"
 
 [features]
 rpc = ["cid"]

--- a/rlay-backend/src/lib.rs
+++ b/rlay-backend/src/lib.rs
@@ -4,6 +4,7 @@ pub mod rpc;
 use futures::future::FutureExt;
 use futures::prelude::*;
 use rlay_ontology::ontology::Entity;
+use std::collections::HashMap;
 use std::future::Future;
 
 pub use failure::Error;
@@ -23,6 +24,12 @@ impl<'a> GetEntity<'a> for std::collections::BTreeMap<&[u8], Entity> {
     fn get_entity(&'a self, cid: &[u8]) -> Self::F {
         future::ready(Ok(self.get(cid).map(|n| n.to_owned()))).boxed()
     }
+}
+
+pub trait ResolveEntity<'a> {
+    type F: Future<Output = Result<HashMap<Vec<u8>, Vec<Entity>>, Error>>;
+
+    fn resolve_entity(&'a self, cid: &[u8]) -> Self::F;
 }
 
 pub trait BackendFromConfigAndSyncState: Sized {

--- a/rlay-backend/src/lib.rs
+++ b/rlay-backend/src/lib.rs
@@ -1,8 +1,9 @@
 #[cfg(feature = "rpc")]
 pub mod rpc;
 
-use futures::future::FutureExt;
-use futures::prelude::*;
+use async_trait::async_trait;
+// use futures::future::FutureExt;
+// use futures::prelude::*;
 use rlay_ontology::ontology::Entity;
 use std::collections::HashMap;
 use std::future::Future;
@@ -12,24 +13,22 @@ pub use futures::future::BoxFuture;
 #[cfg(feature = "rpc")]
 pub use rpc::BackendRpcMethods;
 
-pub trait GetEntity<'a> {
-    type F: Future<Output = Result<Option<Entity>, Error>>;
-
-    fn get_entity(&'a self, cid: &[u8]) -> Self::F;
+#[async_trait]
+pub trait GetEntity {
+    async fn get_entity(&self, cid: &[u8]) -> Result<Option<Entity>, Error>;
 }
 
-impl<'a> GetEntity<'a> for std::collections::BTreeMap<&[u8], Entity> {
-    type F = BoxFuture<'a, Result<Option<Entity>, Error>>;
+// impl<'a> GetEntity<'a> for std::collections::BTreeMap<&[u8], Entity> {
+// type F = BoxFuture<'a, Result<Option<Entity>, Error>>;
 
-    fn get_entity(&'a self, cid: &[u8]) -> Self::F {
-        future::ready(Ok(self.get(cid).map(|n| n.to_owned()))).boxed()
-    }
-}
+// fn get_entity(&'a self, cid: &[u8]) -> Self::F {
+// future::ready(Ok(self.get(cid).map(|n| n.to_owned()))).boxed()
+// }
+// }
 
-pub trait ResolveEntity<'a> {
-    type F: Future<Output = Result<HashMap<Vec<u8>, Vec<Entity>>, Error>>;
-
-    fn resolve_entity(&'a self, cid: &[u8]) -> Self::F;
+#[async_trait]
+pub trait ResolveEntity {
+    async fn resolve_entity(&self, cid: &[u8]) -> Result<HashMap<Vec<u8>, Vec<Entity>>, Error>;
 }
 
 pub trait BackendFromConfigAndSyncState: Sized {

--- a/rlay-client/Cargo.toml
+++ b/rlay-client/Cargo.toml
@@ -33,6 +33,7 @@ hlua = "0.4.1"
 static_assertions = "1.1.0"
 ambassador = "0.2.1"
 libloading = "0.5.2"
+async-trait = "0.1.24"
 
 [dev-dependencies]
 assert_cmd = "0.11"

--- a/rlay-client/src/backend/mod.rs
+++ b/rlay-client/src/backend/mod.rs
@@ -3,7 +3,7 @@ use cid::Cid;
 use failure::Error;
 use futures::future::{BoxFuture, FutureExt, TryFutureExt};
 use rlay_backend::rpc::*;
-use rlay_backend::{BackendFromConfigAndSyncState, GetEntity};
+use rlay_backend::{BackendFromConfigAndSyncState, GetEntity, ResolveEntity};
 use rlay_ontology::ontology::Entity;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -153,6 +153,19 @@ impl<'a> GetEntity<'a> for Backend {
             Backend::Neo4j(backend) => GetEntity::get_entity(backend, cid),
             #[cfg(feature = "backend_redisgraph")]
             Backend::Redisgraph(backend) => GetEntity::get_entity(backend, cid),
+        }
+    }
+}
+
+impl<'a> ResolveEntity<'a> for Backend {
+    type F = BoxFuture<'a, Result<HashMap<Vec<u8>, Vec<Entity>>, Error>>;
+
+    fn resolve_entity(&'a self, cid: &[u8]) -> Self::F {
+        match self {
+            #[cfg(feature = "backend_neo4j")]
+            Backend::Neo4j(backend) => ResolveEntity::resolve_entity(backend, cid),
+            #[cfg(feature = "backend_redisgraph")]
+            Backend::Redisgraph(backend) => ResolveEntity::resolve_entity(backend, cid),
         }
     }
 }

--- a/rlay-client/src/backend/mod.rs
+++ b/rlay-client/src/backend/mod.rs
@@ -1,4 +1,5 @@
 use ambassador::Delegate;
+use async_trait::async_trait;
 use cid::Cid;
 use failure::Error;
 use futures::future::{BoxFuture, FutureExt, TryFutureExt};
@@ -144,28 +145,26 @@ impl BackendRpcMethodResolveEntities for Backend {
 
 impl BackendRpcMethods for Backend {}
 
-impl<'a> GetEntity<'a> for Backend {
-    type F = BoxFuture<'a, Result<Option<Entity>, Error>>;
-
-    fn get_entity(&'a self, cid: &[u8]) -> Self::F {
+#[async_trait]
+impl GetEntity for Backend {
+    async fn get_entity(&self, cid: &[u8]) -> Result<Option<Entity>, Error> {
         match self {
             #[cfg(feature = "backend_neo4j")]
-            Backend::Neo4j(backend) => GetEntity::get_entity(backend, cid),
+            Backend::Neo4j(backend) => GetEntity::get_entity(backend, cid).await,
             #[cfg(feature = "backend_redisgraph")]
-            Backend::Redisgraph(backend) => GetEntity::get_entity(backend, cid),
+            Backend::Redisgraph(backend) => GetEntity::get_entity(backend, cid).await,
         }
     }
 }
 
-impl<'a> ResolveEntity<'a> for Backend {
-    type F = BoxFuture<'a, Result<HashMap<Vec<u8>, Vec<Entity>>, Error>>;
-
-    fn resolve_entity(&'a self, cid: &[u8]) -> Self::F {
+#[async_trait]
+impl ResolveEntity for Backend {
+    async fn resolve_entity(&self, cid: &[u8]) -> Result<HashMap<Vec<u8>, Vec<Entity>>, Error> {
         match self {
             #[cfg(feature = "backend_neo4j")]
-            Backend::Neo4j(backend) => ResolveEntity::resolve_entity(backend, cid),
+            Backend::Neo4j(backend) => ResolveEntity::resolve_entity(backend, cid).await,
             #[cfg(feature = "backend_redisgraph")]
-            Backend::Redisgraph(backend) => ResolveEntity::resolve_entity(backend, cid),
+            Backend::Redisgraph(backend) => ResolveEntity::resolve_entity(backend, cid).await,
         }
     }
 }

--- a/rlay-client/src/plugins.rs
+++ b/rlay-client/src/plugins.rs
@@ -1,22 +1,33 @@
-use ambassador::Delegate;
+use async_trait::async_trait;
 use libloading as lib;
 use libloading::Symbol;
 use rlay_ontology::prelude::Entity;
-use rlay_plugin_interface::prelude::{BoxFuture, FilterContext, RlayFilter};
+use rlay_plugin_interface::prelude::{FilterContext, RlayFilter};
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::sync::Arc;
 
 sa::assert_impl_all!(RlayFilterPlugin: Send, Sync);
-#[derive(Delegate)]
-#[delegate(rlay_plugin_interface::RlayFilter, target = "filter")]
+// #[derive(Delegate)]
+// #[delegate(rlay_plugin_interface::RlayFilter, target = "filter")]
 pub struct RlayFilterPlugin {
     filter: Box<dyn RlayFilter + Send + Sync>,
     // Library that the plugin comes from.
     // Has to be the last field so that it's dropped last
     #[allow(unused)]
     library: lib::Library,
+}
+
+#[async_trait]
+impl RlayFilter for RlayFilterPlugin {
+    fn filter_name(&self) -> &'static str {
+        self.filter.filter_name()
+    }
+
+    async fn filter_entities(&self, ctx: FilterContext, entities: Vec<Entity>) -> Vec<bool> {
+        self.filter.filter_entities(ctx, entities).await
+    }
 }
 
 impl RlayFilterPlugin {

--- a/rlay-client/src/plugins.rs
+++ b/rlay-client/src/plugins.rs
@@ -2,7 +2,7 @@ use ambassador::Delegate;
 use libloading as lib;
 use libloading::Symbol;
 use rlay_ontology::prelude::Entity;
-use rlay_plugin_interface::{FilterContext, RlayFilter};
+use rlay_plugin_interface::prelude::{BoxFuture, FilterContext, RlayFilter};
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::Path;

--- a/rlay-jsonrpc-client/Cargo.toml
+++ b/rlay-jsonrpc-client/Cargo.toml
@@ -16,3 +16,4 @@ rlay_ontology = { version = "0.2.6", features = ["web3_compat"] }
 serde = "1.0.79"
 serde_json = { version = "1.0.22", features = ["preserve_order"] }
 rustc-hex = "2.0"
+async-trait = "0.1.24"

--- a/rlay-jsonrpc-client/src/lib.rs
+++ b/rlay-jsonrpc-client/src/lib.rs
@@ -1,10 +1,11 @@
 #[macro_use]
 extern crate serde_json;
 
+use async_trait::async_trait;
 use failure::err_msg;
 use futures::prelude::*;
 use hyper::{client::HttpConnector, header, Body, Client, Request};
-use rlay_backend::{BoxFuture, GetEntity};
+use rlay_backend::GetEntity;
 use rlay_ontology::ontology::Entity;
 use rlay_ontology::prelude::FormatWeb3;
 use rustc_hex::ToHex;
@@ -99,14 +100,13 @@ impl RlayClient {
     }
 }
 
-impl<'a> GetEntity<'a> for RlayClient {
-    type F = BoxFuture<'a, Result<Option<Entity>, rlay_backend::Error>>;
-
-    fn get_entity(&'a self, cid: &[u8]) -> Self::F {
+#[async_trait]
+impl GetEntity for RlayClient {
+    async fn get_entity(&self, cid: &[u8]) -> Result<Option<Entity>, rlay_backend::Error> {
         let cid_str: String = cid.as_ref().to_hex();
 
         self.get_entity(cid_str)
             .map_err(|_| err_msg("Failure during RPC call"))
-            .boxed()
+            .await
     }
 }

--- a/rlay-plugin-interface/Cargo.toml
+++ b/rlay-plugin-interface/Cargo.toml
@@ -10,4 +10,5 @@ edition = "2018"
 rlay-backend = { path = "../rlay-backend" }
 
 ambassador = "0.2.1"
+serde_json = "1"
 rlay_ontology = { version = "0.2.6", features = ["web3_compat"] }

--- a/rlay-plugin-interface/Cargo.toml
+++ b/rlay-plugin-interface/Cargo.toml
@@ -10,5 +10,6 @@ edition = "2018"
 rlay-backend = { path = "../rlay-backend" }
 
 ambassador = "0.2.1"
+async-trait = "0.1.24"
 serde_json = "1"
 rlay_ontology = { version = "0.2.6", features = ["web3_compat"] }

--- a/rlay-plugin-interface/src/lib.rs
+++ b/rlay-plugin-interface/src/lib.rs
@@ -1,22 +1,44 @@
 pub mod prelude {
-    pub use rlay_backend::GetEntity;
+    pub use rlay_backend::{BoxFuture, GetEntity, ResolveEntity};
     pub use rlay_ontology::ontology::Entity;
+    pub use serde_json::Value;
 
     pub use super::FilterContext;
     pub use super::RlayFilter;
 }
 
 use ambassador::delegatable_trait;
-use rlay_backend::{BoxFuture, Error, GetEntity};
+use rlay_backend::{BoxFuture, Error, GetEntity, ResolveEntity};
 use rlay_ontology::prelude::*;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub trait FilterBackend<'a>:
+    Send
+    + Sync
+    + GetEntity<'a, F = BoxFuture<'a, Result<Option<Entity>, Error>>>
+    + ResolveEntity<'a, F = BoxFuture<'a, Result<HashMap<Vec<u8>, Vec<Entity>>, Error>>>
+{
+}
+
+impl<
+        'a,
+        T: Send
+            + Sync
+            + GetEntity<'a, F = BoxFuture<'a, Result<Option<Entity>, Error>>>
+            + ResolveEntity<'a, F = BoxFuture<'a, Result<HashMap<Vec<u8>, Vec<Entity>>, Error>>>,
+    > FilterBackend<'a> for T
+{
+}
 
 pub struct FilterContext<'a> {
-    pub backend: Box<dyn GetEntity<'a, F = BoxFuture<'a, Result<Option<Entity>, Error>>>>,
+    pub backend: Box<dyn FilterBackend<'a>>,
+    pub params: &'a Value,
 }
 
 #[delegatable_trait]
 pub trait RlayFilter {
     fn filter_name(&self) -> &'static str;
 
-    fn filter_entity(&self, ctx: &FilterContext, entity: &Entity) -> bool;
+    fn filter_entities(&self, ctx: &FilterContext, entities: Vec<Entity>) -> BoxFuture<Vec<bool>>;
 }


### PR DESCRIPTION
- Switch filters to work on batches of entity via `filter_entities`
- Hook up filters to rpc methods for `resolveEntity` and `resolveEntities`
- Switch to using the `async-trait` crate for the `rlay-backend` traits (reduces boilerplate and simplifies lifetime issues with returned futures)